### PR TITLE
:bug: Fix: fix ImgurApi.baseUrl  is undefined

### DIFF
--- a/src/renderer/apis/imgur.ts
+++ b/src/renderer/apis/imgur.ts
@@ -17,8 +17,7 @@ interface IConfig {
 }
 
 export default class ImgurApi {
-  static baseUrl: 'https://api.imgur.com/3'
-
+  static baseUrl = 'https://api.imgur.com/3'
   private static async makeRequest (
     method: 'delete',
     url: string,


### PR DESCRIPTION
处理在相册里开启删除云端功能后，无法删除imgur的图片
![](https://i.imgur.com/UTMioSz.png)