### PR TITLE
修复 S3 兼容空间设置 自定义网址 导致云端无法同步删除

### DIFF
--- a/src/main/utils/deleteFunc.ts
+++ b/src/main/utils/deleteFunc.ts
@@ -88,7 +88,9 @@ async function getDogeToken (accessKey: string, secretKey: string): Promise<IObj
 }
 
 export async function removeFileFromS3InMain (configMap: IStringKeyMap, dogeMode: boolean = false) {
+  console.group('S3 Deletion Debug')
   try {
+    console.log('S3_DELETE: Received configMap:', JSON.stringify(configMap, null, 2))
     const {
       url: rawUrl,
       type,
@@ -110,6 +112,9 @@ export async function removeFileFromS3InMain (configMap: IStringKeyMap, dogeMode
     if (type === 'aws-s3' || type === 'aws-s3-plist') {
       imgUrl = rawUrl || imgUrl || ''
     }
+    console.log('S3_DELETE: Initial imgUrl:', imgUrl)
+    console.log('S3_DELETE: Custom URL from config:', customUrl)
+
     let fileKey
     if (customUrl && imgUrl.startsWith(customUrl)) {
       const customUrlObj = new URL(customUrl)
@@ -119,12 +124,14 @@ export async function removeFileFromS3InMain (configMap: IStringKeyMap, dogeMode
       } else {
         fileKey = imgUrlObj.pathname.replace(/^\/+/, '')
       }
+      console.log('S3_DELETE: Calculated fileKey (custom URL path):', fileKey)
     } else {
       const url = new URL(!/^https?:\/\//.test(imgUrl) ? `http://${imgUrl}` : imgUrl)
       fileKey = url.pathname.replace(/^\/+/, '')
       if (pathStyleAccess) {
         fileKey = fileKey.replace(/^[^/]+\//, '')
       }
+      console.log('S3_DELETE: Calculated fileKey (standard path):', fileKey)
     }
     const endpointUrl: string | undefined = endpoint
       ? /^https?:\/\//.test(endpoint)
@@ -180,26 +187,36 @@ export async function removeFileFromS3InMain (configMap: IStringKeyMap, dogeMode
     let result: any
     try {
       fileKey = decodeURIComponent(fileKey)
-    } catch (err: any) {}
+      console.log('S3_DELETE: Decoded fileKey:', fileKey)
+    } catch (err: any) {
+      console.error('S3_DELETE: Failed to decode fileKey', err)
+    }
     try {
       const client = new S3Client(s3Options)
       const command = new DeleteObjectCommand({
         Bucket: bucketName,
         Key: fileKey
       })
+      console.log('S3_DELETE: Sending DeleteObjectCommand with Bucket:', bucketName, 'Key:', fileKey)
       result = await client.send(command)
+      console.log('S3_DELETE: S3 command result:', result)
     } catch (err: any) {
+      console.error('S3_DELETE: First attempt to delete failed. Full error:', err)
       s3Options.region = 'us-east-1'
       const client = new S3Client(s3Options)
       const command = new DeleteObjectCommand({
         Bucket: bucketName,
         Key: fileKey
       })
+      console.log('S3_DELETE: Retrying DeleteObjectCommand with Bucket:', bucketName, 'Key:', fileKey, 'Region: us-east-1')
       result = await client.send(command)
+      console.log('S3_DELETE: S3 retry command result:', result)
     }
+    console.groupEnd()
     return result.$metadata.httpStatusCode === 204
   } catch (err: any) {
-    console.log(err)
+    console.error('S3_DELETE: An unexpected error occurred in removeFileFromS3InMain. Full error:', err)
+    console.groupEnd()
     return false
   }
 }

--- a/src/main/utils/deleteFunc.ts
+++ b/src/main/utils/deleteFunc.ts
@@ -92,7 +92,16 @@ export async function removeFileFromS3InMain (configMap: IStringKeyMap, dogeMode
     const {
       url: rawUrl,
       type,
-      config: { accessKeyID, secretAccessKey, bucketName, endpoint, pathStyleAccess, rejectUnauthorized, proxy }
+      config: {
+        accessKeyID,
+        secretAccessKey,
+        bucketName,
+        endpoint,
+        pathStyleAccess,
+        rejectUnauthorized,
+        proxy,
+        customUrl
+      }
     } = configMap
     let {
       imgUrl,
@@ -101,10 +110,21 @@ export async function removeFileFromS3InMain (configMap: IStringKeyMap, dogeMode
     if (type === 'aws-s3' || type === 'aws-s3-plist') {
       imgUrl = rawUrl || imgUrl || ''
     }
-    const url = new URL(!/^https?:\/\//.test(imgUrl) ? `http://${imgUrl}` : imgUrl)
-    let fileKey = url.pathname.replace(/^\/+/, '')
-    if (pathStyleAccess) {
-      fileKey = fileKey.replace(/^[^/]+\//, '')
+    let fileKey
+    if (customUrl && imgUrl.startsWith(customUrl)) {
+      const customUrlObj = new URL(customUrl)
+      const imgUrlObj = new URL(imgUrl)
+      if (imgUrlObj.pathname.startsWith(customUrlObj.pathname)) {
+        fileKey = imgUrlObj.pathname.substring(customUrlObj.pathname.length).replace(/^\/+/, '')
+      } else {
+        fileKey = imgUrlObj.pathname.replace(/^\/+/, '')
+      }
+    } else {
+      const url = new URL(!/^https?:\/\//.test(imgUrl) ? `http://${imgUrl}` : imgUrl)
+      fileKey = url.pathname.replace(/^\/+/, '')
+      if (pathStyleAccess) {
+        fileKey = fileKey.replace(/^[^/]+\//, '')
+      }
     }
     const endpointUrl: string | undefined = endpoint
       ? /^https?:\/\//.test(endpoint)

--- a/src/main/utils/deleteFunc.ts
+++ b/src/main/utils/deleteFunc.ts
@@ -88,9 +88,7 @@ async function getDogeToken (accessKey: string, secretKey: string): Promise<IObj
 }
 
 export async function removeFileFromS3InMain (configMap: IStringKeyMap, dogeMode: boolean = false) {
-  console.group('S3 Deletion Debug')
   try {
-    console.log('S3_DELETE: Received configMap:', JSON.stringify(configMap, null, 2))
     const {
       url: rawUrl,
       type,
@@ -102,7 +100,7 @@ export async function removeFileFromS3InMain (configMap: IStringKeyMap, dogeMode
         pathStyleAccess,
         rejectUnauthorized,
         proxy,
-        customUrl
+        urlPrefix
       }
     } = configMap
     let {
@@ -112,26 +110,21 @@ export async function removeFileFromS3InMain (configMap: IStringKeyMap, dogeMode
     if (type === 'aws-s3' || type === 'aws-s3-plist') {
       imgUrl = rawUrl || imgUrl || ''
     }
-    console.log('S3_DELETE: Initial imgUrl:', imgUrl)
-    console.log('S3_DELETE: Custom URL from config:', customUrl)
-
     let fileKey
-    if (customUrl && imgUrl.startsWith(customUrl)) {
-      const customUrlObj = new URL(customUrl)
+    if (urlPrefix && imgUrl.startsWith(urlPrefix)) {
+      const urlPrefixObj = new URL(urlPrefix)
       const imgUrlObj = new URL(imgUrl)
-      if (imgUrlObj.pathname.startsWith(customUrlObj.pathname)) {
-        fileKey = imgUrlObj.pathname.substring(customUrlObj.pathname.length).replace(/^\/+/, '')
+      if (imgUrlObj.pathname.startsWith(urlPrefixObj.pathname)) {
+        fileKey = imgUrlObj.pathname.substring(urlPrefixObj.pathname.length).replace(/^\/+/, '')
       } else {
         fileKey = imgUrlObj.pathname.replace(/^\/+/, '')
       }
-      console.log('S3_DELETE: Calculated fileKey (custom URL path):', fileKey)
     } else {
       const url = new URL(!/^https?:\/\//.test(imgUrl) ? `http://${imgUrl}` : imgUrl)
       fileKey = url.pathname.replace(/^\/+/, '')
       if (pathStyleAccess) {
         fileKey = fileKey.replace(/^[^/]+\//, '')
       }
-      console.log('S3_DELETE: Calculated fileKey (standard path):', fileKey)
     }
     const endpointUrl: string | undefined = endpoint
       ? /^https?:\/\//.test(endpoint)
@@ -187,36 +180,26 @@ export async function removeFileFromS3InMain (configMap: IStringKeyMap, dogeMode
     let result: any
     try {
       fileKey = decodeURIComponent(fileKey)
-      console.log('S3_DELETE: Decoded fileKey:', fileKey)
-    } catch (err: any) {
-      console.error('S3_DELETE: Failed to decode fileKey', err)
-    }
+    } catch (err: any) {}
     try {
       const client = new S3Client(s3Options)
       const command = new DeleteObjectCommand({
         Bucket: bucketName,
         Key: fileKey
       })
-      console.log('S3_DELETE: Sending DeleteObjectCommand with Bucket:', bucketName, 'Key:', fileKey)
       result = await client.send(command)
-      console.log('S3_DELETE: S3 command result:', result)
     } catch (err: any) {
-      console.error('S3_DELETE: First attempt to delete failed. Full error:', err)
       s3Options.region = 'us-east-1'
       const client = new S3Client(s3Options)
       const command = new DeleteObjectCommand({
         Bucket: bucketName,
         Key: fileKey
       })
-      console.log('S3_DELETE: Retrying DeleteObjectCommand with Bucket:', bucketName, 'Key:', fileKey, 'Region: us-east-1')
       result = await client.send(command)
-      console.log('S3_DELETE: S3 retry command result:', result)
     }
-    console.groupEnd()
     return result.$metadata.httpStatusCode === 204
   } catch (err: any) {
-    console.error('S3_DELETE: An unexpected error occurred in removeFileFromS3InMain. Full error:', err)
-    console.groupEnd()
+    console.log(err)
     return false
   }
 }


### PR DESCRIPTION
Hello，昨天晚上我又测试了多个 S3 兼容网盘，都会出现同样的问题

今天早上检查程序时发现，问题在于当您设置了 “自定义网址” 后，程序在删除云端文件时，没有正确计算出文件在 S3 存储空间中的实际路径。它错误地将自定义网址的一部分也当成了文件路径，导致 S3 找不到要删除的文件，所以删除失败了（即使界面显示成功）。

我所做的修改就是修正了这个计算逻辑，确保在使用自定义网址时，程序也能找到正确的文件路径并成功删除。这个问题现在应该已经解决了。

修改 S3 文件删除逻辑：我将编辑位于 src/main/utils/deleteFunc.ts 文件中的 removeFileFromS3InMain 函数。

实现新的网址解析逻辑：在函数中，我加入了一段新的判断逻辑。如果系统检测到您设置了 “自定义网址”（urlPrefix），程序在删除文件前，会先从图片的完整网址中移除这个自定义网址的部分，从而得到真正在 S3 上存储的文件路径（Object Key）。对于没有设置自定义网址的情况，则会沿用原本的处理方式。

修正（S3）：正确处理自定义 URL 的文件删除问题
当为 S3 兼容的提供者设置自定义 URL 时，应用程序无法从远程存储桶中删除文件。这是因为删除逻辑错误地将自定义 URL 的完整路径名称用作 S3 对象密钥，而不是存储桶中对象的实际密钥。

此提交修改了 removeFileFromS3InMain 函数，使其能识别 urlPrefix 设置。如果正在使用自定义 URL，现在的逻辑会在发送 DeleteObject 命令之前，正确地从影像 URL 中去除自定义 URL 的前缀，以得出正确的 S3 对象密钥。

目前已经在多个兼容空间测试过，应该完全没问题了，再麻烦您最终确认后合并进主分支，感谢！