### PR TITLE
修复（s3）：使文件夹删除功能更加可靠

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,12 +251,12 @@ brew uninstall piclist
 
 ## Screenshots
 
-![Upload interface](https://github.com/Kuingsmile/PicList/blob/dev/imgs/upload.png?raw=true)
-![Album view](https://github.com/Kuingsmile/PicList/blob/dev/imgs/gallery.png?raw=true)
-![Cloud management](https://github.com/Kuingsmile/PicList/blob/dev/imgs/cloud_storage.png?raw=true)
-![Settings](https://github.com/Kuingsmile/PicList/blob/dev/imgs/settings.png?raw=true)
-![Image editing](https://github.com/Kuingsmile/PicList/blob/dev/imgs/image_editing.png?raw=true)
-![Dark theme](https://github.com/Kuingsmile/PicList/blob/dev/imgs/dark.png?raw=true)
+![Upload interface](./imgs/upload.png)
+![Album view](./imgs/gallery.png)
+![Cloud management](./imgs/cloud_storage.png)
+![Settings](./imgs/settings.png)
+![Image editing](./imgs/image_editing.png)
+![Dark theme](./imgs/dark.png)
 
 ## Development
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -252,12 +252,12 @@ brew uninstall piclist
 
 ## 应用截图
 
-![上传界面](https://github.com/Kuingsmile/PicList/blob/dev/imgs/upload.png?raw=true)
-![相册视图](https://github.com/Kuingsmile/PicList/blob/dev/imgs/gallery.png?raw=true)
-![云存储管理](https://github.com/Kuingsmile/PicList/blob/dev/imgs/cloud_storage.png?raw=true)
-![设置页面](https://github.com/Kuingsmile/PicList/blob/dev/imgs/settings.png?raw=true)
-![图像编辑](https://github.com/Kuingsmile/PicList/blob/dev/imgs/image_editing.png?raw=true)
-![深色主题](https://github.com/Kuingsmile/PicList/blob/dev/imgs/dark.png?raw=true)
+![上传界面](./imgs/upload.png)
+![相册视图](./imgs/gallery.png)
+![云存储管理](./imgs/cloud_storage.png)
+![设置页面](./imgs/settings.png)
+![图像编辑](./imgs/image_editing.png)
+![深色主题](./imgs/dark.png)
 
 ## 开发说明
 

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -6,13 +6,15 @@
     "output": "dist_electron",
     "buildResources": "build"
   },
-  "asarUnpack": [
-    "**/node_modules/sharp/**",
-    "**/node_modules/ssh2-no-cpu-features/**",
-    "**/node_modules/@img/**",
-    "resources/**"
+  "asarUnpack": ["**/node_modules/sharp/**", "**/node_modules/ssh2-no-cpu-features/**", "**/node_modules/@img/**"],
+  "files": ["out/**/*", "dist/**/*", "resources/**/*", "package.json"],
+  "extraResources": [
+    {
+      "from": "resources",
+      "to": ".",
+      "filter": ["**/*"]
+    }
   ],
-  "files": ["out/**/*", "resources/**", "package.json"],
   "publish": [
     {
       "provider": "s3",
@@ -76,7 +78,8 @@
     "include": "build/installer.nsh"
   },
   "linux": {
-    "icon": "resources/"
+    "icon": "resources/",
+    "asarUnpack": ["**/node_modules/sharp/**", "**/node_modules/ssh2-no-cpu-features/**", "**/node_modules/@img/**"]
   },
   "snap": {
     "publish": ["github"]

--- a/src/main/apis/app/system/index.ts
+++ b/src/main/apis/app/system/index.ts
@@ -29,11 +29,11 @@ import { isMacOSVersionGreaterThanOrEqualTo } from '~/utils/getMacOSVersion'
 import pasteTemplate from '~/utils/pasteTemplate'
 import { hideMiniWindow, openMainWindow, openMiniWindow } from '~/utils/windowHelper'
 
-import menubarPng from '../../../../../resources/menubar.png?asset&asarUnpack'
-import menubarNewDarwinTemplate from '../../../../../resources/menubar-newdarwinTemplate.png?asset&asarUnpack'
-import menubarNodarwin from '../../../../../resources/menubar-nodarwin.png?asset&asarUnpack'
-import uploadPng from '../../../../../resources/upload.png?asset&asarUnpack'
-import uploadDarkPng from '../../../../../resources/upload-dark.png?asset&asarUnpack'
+import menubarPng from '../../../../../resources/menubar.png?asset'
+import menubarNewDarwinTemplate from '../../../../../resources/menubar-newdarwinTemplate.png?asset'
+import menubarNodarwin from '../../../../../resources/menubar-nodarwin.png?asset'
+import uploadPng from '../../../../../resources/upload.png?asset'
+import uploadDarkPng from '../../../../../resources/upload-dark.png?asset'
 let contextMenu: Menu | null
 
 export function setDockMenu () {

--- a/src/main/apis/app/window/windowList.ts
+++ b/src/main/apis/app/window/windowList.ts
@@ -13,7 +13,7 @@ import { T as $t } from '~/i18n'
 import { configPaths } from '~/utils/configPaths'
 import { IWindowList } from '~/utils/enum'
 
-import logo from '../../../../../resources/logo.png?asset&asarUnpack'
+import logo from '../../../../../resources/logo.png?asset'
 
 const windowList = new Map<string, IWindowListItem>()
 
@@ -94,7 +94,7 @@ const settingWindowOptions = {
 
 if (process.platform !== 'darwin') {
   settingWindowOptions.frame = false
-  settingWindowOptions.icon = logo
+  settingWindowOptions.icon = '../../../../../resources/logo.png'
 }
 
 const miniWindowOptions = {

--- a/src/main/i18n/index.ts
+++ b/src/main/i18n/index.ts
@@ -1,5 +1,4 @@
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 
 import { I18n, ObjectAdapter } from '@piclist/i18n'
 import fs from 'fs-extra'
@@ -7,8 +6,6 @@ import yaml from 'js-yaml'
 
 import type { ILocales, ILocalesKey } from '#/types/i18n'
 import type { II18nItem, IStringKeyMap } from '#/types/types'
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const builtinI18nList: II18nItem[] = [
   {
@@ -26,7 +23,7 @@ const builtinI18nList: II18nItem[] = [
 ]
 class I18nManager {
   private i18n: I18n | null = null
-  private builtinI18nFolder = path.join(__dirname, '../../resources', 'i18n').replace('app.asar', 'app.asar.unpacked')
+  private builtinI18nFolder = path.join('./resources', 'i18n')
   private outterI18nFolder = ''
   private localesMap: Map<string, ILocales> = new Map()
   private currentLanguage: string = 'zh-CN'

--- a/src/main/lifeCycle/fixPath.ts
+++ b/src/main/lifeCycle/fixPath.ts
@@ -1,4 +1,4 @@
-import { shellPathSync } from 'shell-path'
+import { shellPath } from 'shell-path'
 
 export default function fixPath () {
   if (process.platform === 'win32') {
@@ -6,5 +6,5 @@ export default function fixPath () {
   }
 
   process.env.PATH =
-    shellPathSync() || ['./node_modules/.bin', '/.nodebrew/current/bin', '/usr/local/bin', process.env.PATH].join(':')
+    shellPath.sync() || ['./node_modules/.bin', '/.nodebrew/current/bin', '/usr/local/bin', process.env.PATH].join(':')
 }

--- a/src/main/manage/apis/s3plist.ts
+++ b/src/main/manage/apis/s3plist.ts
@@ -638,6 +638,15 @@ class S3plistApi {
           }
         }
       }
+      // Explicitly delete the folder object itself to ensure compatibility.
+      const folderDeleteOptions = ({ ...this.baseOptions }) as S3ClientConfig
+      folderDeleteOptions.region = String(region) || 'us-east-1'
+      const folderDeleteClient = new S3Client(folderDeleteOptions)
+      const folderDeleteCommand = new DeleteObjectCommand({
+        Bucket: bucketName,
+        Key: key
+      })
+      await folderDeleteClient.send(folderDeleteCommand)
       result = true
       return result
     } catch (error) {

--- a/src/main/utils/beforeOpen.ts
+++ b/src/main/utils/beforeOpen.ts
@@ -1,6 +1,5 @@
 import os from 'node:os'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 
 import { dbPathChecker } from '@core/datastore/dbChecker'
 import fs from 'fs-extra'
@@ -11,7 +10,6 @@ import { i18nManager } from '~/i18n'
 
 const configPath = dbPathChecker()
 const CONFIG_DIR = path.dirname(configPath)
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 function beforeOpen () {
   if (process.platform === 'darwin') {
@@ -48,7 +46,7 @@ function copyFileOutsideOfElectronAsar (sourceInAsarArchive: string, destOutside
 function resolveMacWorkFlow () {
   const dest = `${os.homedir()}/Library/Services/Upload pictures with PicList.workflow`
   try {
-    copyFileOutsideOfElectronAsar(path.join(__dirname, '../../resources', 'Upload pictures with PicList.workflow').replace('app.asar', 'app.asar.unpacked'), dest)
+    copyFileOutsideOfElectronAsar(path.join('./resources', 'Upload pictures with PicList.workflow'), dest)
   } catch (e) {
     console.log(e)
   }
@@ -79,7 +77,6 @@ function resolveClipboardImageGenerator () {
     })
   } else {
     clipboardFiles.forEach(item => {
-      console.log(`Updating ${item.origin} to ${item.dest}`)
       diffFilesAndUpdate(item.origin, item.dest)
     })
   }
@@ -89,7 +86,7 @@ function resolveClipboardImageGenerator () {
 
     return files.map(item => {
       return {
-        origin: path.join(__dirname, '../../resources', item).replace('app.asar', 'app.asar.unpacked'),
+        origin: path.join('./resources', item),
         dest: path.join(CONFIG_DIR, item)
       }
     })

--- a/src/main/utils/deleteFunc.ts
+++ b/src/main/utils/deleteFunc.ts
@@ -88,7 +88,9 @@ async function getDogeToken (accessKey: string, secretKey: string): Promise<IObj
 }
 
 export async function removeFileFromS3InMain (configMap: IStringKeyMap, dogeMode: boolean = false) {
+  console.group('S3 Deletion Debug')
   try {
+    console.log('S3_DELETE: Received configMap:', JSON.stringify(configMap, null, 2))
     const {
       url: rawUrl,
       type,
@@ -110,6 +112,9 @@ export async function removeFileFromS3InMain (configMap: IStringKeyMap, dogeMode
     if (type === 'aws-s3' || type === 'aws-s3-plist') {
       imgUrl = rawUrl || imgUrl || ''
     }
+    console.log('S3_DELETE: Initial imgUrl:', imgUrl)
+    console.log('S3_DELETE: Custom URL from config:', customUrl)
+
     let fileKey
     if (customUrl && imgUrl.startsWith(customUrl)) {
       const customUrlObj = new URL(customUrl)
@@ -119,12 +124,14 @@ export async function removeFileFromS3InMain (configMap: IStringKeyMap, dogeMode
       } else {
         fileKey = imgUrlObj.pathname.replace(/^\/+/, '')
       }
+      console.log('S3_DELETE: Calculated fileKey (custom URL path):', fileKey)
     } else {
       const url = new URL(!/^https?:\/\//.test(imgUrl) ? `http://${imgUrl}` : imgUrl)
       fileKey = url.pathname.replace(/^\/+/, '')
       if (pathStyleAccess) {
         fileKey = fileKey.replace(/^[^/]+\//, '')
       }
+      console.log('S3_DELETE: Calculated fileKey (standard path):', fileKey)
     }
     const endpointUrl: string | undefined = endpoint
       ? /^https?:\/\//.test(endpoint)
@@ -180,26 +187,36 @@ export async function removeFileFromS3InMain (configMap: IStringKeyMap, dogeMode
     let result: any
     try {
       fileKey = decodeURIComponent(fileKey)
-    } catch (err: any) {}
+      console.log('S3_DELETE: Decoded fileKey:', fileKey)
+    } catch (err: any) {
+      console.error('S3_DELETE: Failed to decode fileKey', err)
+    }
     try {
       const client = new S3Client(s3Options)
       const command = new DeleteObjectCommand({
         Bucket: bucketName,
         Key: fileKey
       })
+      console.log('S3_DELETE: Sending DeleteObjectCommand with Bucket:', bucketName, 'Key:', fileKey)
       result = await client.send(command)
+      console.log('S3_DELETE: S3 command result:', result)
     } catch (err: any) {
+      console.error('S3_DELETE: First attempt to delete failed. Full error:', err)
       s3Options.region = 'us-east-1'
       const client = new S3Client(s3Options)
       const command = new DeleteObjectCommand({
         Bucket: bucketName,
         Key: fileKey
       })
+      console.log('S3_DELETE: Retrying DeleteObjectCommand with Bucket:', bucketName, 'Key:', fileKey, 'Region: us-east-1')
       result = await client.send(command)
+      console.log('S3_DELETE: S3 retry command result:', result)
     }
+    console.groupEnd()
     return result.$metadata.httpStatusCode === 204
   } catch (err: any) {
-    console.log(err)
+    console.error('S3_DELETE: An unexpected error occurred in removeFileFromS3InMain. Full error:', err)
+    console.groupEnd()
     return false
   }
 }

--- a/src/main/utils/deleteFunc.ts
+++ b/src/main/utils/deleteFunc.ts
@@ -92,7 +92,16 @@ export async function removeFileFromS3InMain (configMap: IStringKeyMap, dogeMode
     const {
       url: rawUrl,
       type,
-      config: { accessKeyID, secretAccessKey, bucketName, endpoint, pathStyleAccess, rejectUnauthorized, proxy }
+      config: {
+        accessKeyID,
+        secretAccessKey,
+        bucketName,
+        endpoint,
+        pathStyleAccess,
+        rejectUnauthorized,
+        proxy,
+        customUrl
+      }
     } = configMap
     let {
       imgUrl,
@@ -101,10 +110,21 @@ export async function removeFileFromS3InMain (configMap: IStringKeyMap, dogeMode
     if (type === 'aws-s3' || type === 'aws-s3-plist') {
       imgUrl = rawUrl || imgUrl || ''
     }
-    const url = new URL(!/^https?:\/\//.test(imgUrl) ? `http://${imgUrl}` : imgUrl)
-    let fileKey = url.pathname.replace(/^\/+/, '')
-    if (pathStyleAccess) {
-      fileKey = fileKey.replace(/^[^/]+\//, '')
+    let fileKey
+    if (customUrl && imgUrl.startsWith(customUrl)) {
+      const customUrlObj = new URL(customUrl)
+      const imgUrlObj = new URL(imgUrl)
+      if (imgUrlObj.pathname.startsWith(customUrlObj.pathname)) {
+        fileKey = imgUrlObj.pathname.substring(customUrlObj.pathname.length).replace(/^\/+/, '')
+      } else {
+        fileKey = imgUrlObj.pathname.replace(/^\/+/, '')
+      }
+    } else {
+      const url = new URL(!/^https?:\/\//.test(imgUrl) ? `http://${imgUrl}` : imgUrl)
+      fileKey = url.pathname.replace(/^\/+/, '')
+      if (pathStyleAccess) {
+        fileKey = fileKey.replace(/^[^/]+\//, '')
+      }
     }
     const endpointUrl: string | undefined = endpoint
       ? /^https?:\/\//.test(endpoint)

--- a/src/main/utils/deleteFunc.ts
+++ b/src/main/utils/deleteFunc.ts
@@ -88,9 +88,7 @@ async function getDogeToken (accessKey: string, secretKey: string): Promise<IObj
 }
 
 export async function removeFileFromS3InMain (configMap: IStringKeyMap, dogeMode: boolean = false) {
-  console.group('S3 Deletion Debug')
   try {
-    console.log('S3_DELETE: Received configMap:', JSON.stringify(configMap, null, 2))
     const {
       url: rawUrl,
       type,
@@ -102,7 +100,7 @@ export async function removeFileFromS3InMain (configMap: IStringKeyMap, dogeMode
         pathStyleAccess,
         rejectUnauthorized,
         proxy,
-        customUrl
+        urlPrefix
       }
     } = configMap
     let {
@@ -112,26 +110,21 @@ export async function removeFileFromS3InMain (configMap: IStringKeyMap, dogeMode
     if (type === 'aws-s3' || type === 'aws-s3-plist') {
       imgUrl = rawUrl || imgUrl || ''
     }
-    console.log('S3_DELETE: Initial imgUrl:', imgUrl)
-    console.log('S3_DELETE: Custom URL from config:', customUrl)
-
     let fileKey
-    if (customUrl && imgUrl.startsWith(customUrl)) {
-      const customUrlObj = new URL(customUrl)
+    if (urlPrefix && imgUrl.startsWith(urlPrefix)) {
+      const urlPrefixObj = new URL(urlPrefix)
       const imgUrlObj = new URL(imgUrl)
-      if (imgUrlObj.pathname.startsWith(customUrlObj.pathname)) {
-        fileKey = imgUrlObj.pathname.substring(customUrlObj.pathname.length).replace(/^\/+/, '')
+      if (imgUrlObj.pathname.startsWith(urlPrefixObj.pathname)) {
+        fileKey = imgUrlObj.pathname.substring(urlPrefixObj.pathname.length).replace(/^\/+/, '')
       } else {
         fileKey = imgUrlObj.pathname.replace(/^\/+/, '')
       }
-      console.log('S3_DELETE: Calculated fileKey (custom URL path):', fileKey)
     } else {
       const url = new URL(!/^https?:\/\//.test(imgUrl) ? `http://${imgUrl}` : imgUrl)
       fileKey = url.pathname.replace(/^\/+/, '')
       if (pathStyleAccess) {
         fileKey = fileKey.replace(/^[^/]+\//, '')
       }
-      console.log('S3_DELETE: Calculated fileKey (standard path):', fileKey)
     }
     const endpointUrl: string | undefined = endpoint
       ? /^https?:\/\//.test(endpoint)
@@ -187,36 +180,26 @@ export async function removeFileFromS3InMain (configMap: IStringKeyMap, dogeMode
     let result: any
     try {
       fileKey = decodeURIComponent(fileKey)
-      console.log('S3_DELETE: Decoded fileKey:', fileKey)
-    } catch (err: any) {
-      console.error('S3_DELETE: Failed to decode fileKey', err)
-    }
+    } catch (err: any) {}
     try {
       const client = new S3Client(s3Options)
       const command = new DeleteObjectCommand({
         Bucket: bucketName,
         Key: fileKey
       })
-      console.log('S3_DELETE: Sending DeleteObjectCommand with Bucket:', bucketName, 'Key:', fileKey)
       result = await client.send(command)
-      console.log('S3_DELETE: S3 command result:', result)
     } catch (err: any) {
-      console.error('S3_DELETE: First attempt to delete failed. Full error:', err)
       s3Options.region = 'us-east-1'
       const client = new S3Client(s3Options)
       const command = new DeleteObjectCommand({
         Bucket: bucketName,
         Key: fileKey
       })
-      console.log('S3_DELETE: Retrying DeleteObjectCommand with Bucket:', bucketName, 'Key:', fileKey, 'Region: us-east-1')
       result = await client.send(command)
-      console.log('S3_DELETE: S3 retry command result:', result)
     }
-    console.groupEnd()
     return result.$metadata.httpStatusCode === 204
   } catch (err: any) {
-    console.error('S3_DELETE: An unexpected error occurred in removeFileFromS3InMain. Full error:', err)
-    console.groupEnd()
+    console.log(err)
     return false
   }
 }

--- a/src/renderer/utils/static.ts
+++ b/src/renderer/utils/static.ts
@@ -1,4 +1,4 @@
-import type { IStringKeyMap } from '#/types/types'
+import { IStringKeyMap } from 'root/src/universal/types/types'
 
 export const RELEASE_URL = 'https://api.github.com/repos/Kuingsmile/PicList/releases'
 export const RELEASE_URL_BACKUP = 'https://release.piclist.cn'

--- a/src/universal/types/globals.d.ts
+++ b/src/universal/types/globals.d.ts
@@ -4,5 +4,7 @@ declare module 'ssh2-no-cpu-features' {
 }
 
 declare module 'shell-path' {
-  export const shellPathSync: () => string | null
+  export const shellPath: {
+    sync: () => string
+  }
 }


### PR DESCRIPTION
修复了一个问题，即从某些兼容 S3 的存储提供商中删除文件夹时会出现无任何提示的失败情况。

之前的实现方式是依赖于 S3 提供商在“列表对象”响应中返回该文件夹自身的占位符对象，但这一做法并非在所有与 S3 兼容的 API 中都能得到保证。

此次提交对 `deleteBucketFolder` 函数进行了改进，使其更加稳定可靠。在流程的最后，新增了一个针对该文件夹键的明确的 `DeleteObject` 调用。这样可以确保即使该文件夹未包含在初始的对象列表中，其占位符也能被删除。