### PR TITLE
Fix: S3 folder deletion not working for some services

### DIFF
--- a/src/main/manage/apis/s3plist.ts
+++ b/src/main/manage/apis/s3plist.ts
@@ -580,10 +580,10 @@ class S3plistApi {
     }
     try {
       await this.getDogeCloudToken()
+      const options = { ...this.baseOptions } as S3ClientConfig
+      options.region = String(region) || 'us-east-1'
+      const client = new S3Client(options)
       do {
-        const options = { ...this.baseOptions } as S3ClientConfig
-        options.region = String(region) || 'us-east-1'
-        const client = new S3Client(options)
         const command = new ListObjectsV2Command({
           Bucket: bucketName,
           Prefix: key,
@@ -604,21 +604,18 @@ class S3plistApi {
       } while (IsTruncated)
       if (allFileList.CommonPrefixes.length > 0) {
         for (const item of allFileList.CommonPrefixes) {
-          res = await this.deleteBucketFolder({
+          const deleteResult = await this.deleteBucketFolder({
             bucketName,
             region,
             key: item.Prefix
           })
-          if (!res) {
+          if (!deleteResult) {
             return result
           }
         }
       }
       if (allFileList.Contents.length > 0) {
         const cycle = Math.ceil(allFileList.Contents.length / 1000)
-        const options = { ...this.baseOptions } as S3ClientConfig
-        options.region = String(region) || 'us-east-1'
-        const client = new S3Client(options)
         for (let i = 0; i < cycle; i++) {
           const deleteList = allFileList.Contents.slice(i * 1000, (i + 1) * 1000)
           const deleteCommand = new DeleteObjectsCommand({
@@ -638,6 +635,11 @@ class S3plistApi {
           }
         }
       }
+      const deleteObjectCommand = new DeleteObjectCommand({
+        Bucket: bucketName,
+        Key: key
+      })
+      await client.send(deleteObjectCommand)
       result = true
       return result
     } catch (error) {


### PR DESCRIPTION
The S3 folder deletion was failing on some S3-compatible services because the folder's own placeholder object was not being deleted. This was happening because the API for listing folder contents on these services does not include the folder's placeholder object.

This commit fixes the issue by adding an explicit `DeleteObject` command to the `deleteBucketFolder` function in `src/main/manage/apis/s3plist.ts`. This command is executed after all the contents and subfolders of the folder have been deleted, ensuring that the folder's own key (e.g., `my-folder/`) is also deleted. This change improves the compatibility of the folder deletion feature with different S3 services.