### PR TITLE
Fix(ui): macos displays Windows title bar

### DIFF
--- a/src/renderer/components/ui/TitleBar.vue
+++ b/src/renderer/components/ui/TitleBar.vue
@@ -27,15 +27,17 @@
           >
             <PinIcon :color="isAlwaysOnTop ? '#CE6769' : '#6B7280'" :size="14" />
           </button>
-          <button class="control-button minimize-button" :title="$t('titleBar.minimize')" @click="minimizeWindow">
-            <MinusIcon :size="14" />
-          </button>
-          <button class="control-button mini-button" :title="$t('titleBar.miniWindow')" @click="openMiniWindow">
-            <ShrinkIcon :size="14" />
-          </button>
-          <button class="control-button close-button" :title="$t('titleBar.close')" @click="closeWindow">
-            <XIcon :size="14" />
-          </button>
+          <template v-if="osGlobal !== 'darwin'">
+            <button class="control-button minimize-button" :title="$t('titleBar.minimize')" @click="minimizeWindow">
+              <MinusIcon :size="14" />
+            </button>
+            <button class="control-button mini-button" :title="$t('titleBar.miniWindow')" @click="openMiniWindow">
+              <ShrinkIcon :size="14" />
+            </button>
+            <button class="control-button close-button" :title="$t('titleBar.close')" @click="closeWindow">
+              <XIcon :size="14" />
+            </button>
+          </template>
         </div>
       </div>
     </div>


### PR DESCRIPTION
在MacOS下，默认显示Windows的窗口控制按钮。这个PR把windows的三个按钮都隐藏了。但是保留了置顶的按钮。 

之前
<img width="800" height="450" alt="image" src="https://github.com/user-attachments/assets/4a270a2b-38fb-4082-b601-5dcc5375172e" />

之后
<img width="800" height="450" alt="image" src="https://github.com/user-attachments/assets/b148570d-bb44-474b-be23-711482d74b70" />
